### PR TITLE
Add GitHub Actions CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,61 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main   
+
+jobs:
+  backend-ci:
+    name: Backend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint     
+      - name: Run tests
+        run: npm test         
+
+  frontend-ci:
+    name: Frontend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint      # o eslint . --ext .js,.jsx,.ts,.tsx
+      - name: Run tests
+        run: npm test          
+
+
+  deploy:
+    name: Deploy to Railway
+    needs: [backend-ci, frontend-ci]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Railway CLI
+        run: |
+          curl -sSL https://railway.app/install.sh | sh
+          echo "PATH=\$HOME/.railway/bin:\$PATH" >> $GITHUB_ENV
+      - name: Deploy Backend
+        run: railway up --service snapbuy-backend --token ${{ secrets.RAILWAY_TOKEN }} --yes
+      - name: Deploy Frontend
+        run: railway up --service snapbuy-frontend --token ${{ secrets.RAILWAY_TOKEN }} --yes


### PR DESCRIPTION
- Define backend CI job: checkout, setup Node.js 22, install, lint, and test
- Define frontend CI job: checkout, setup Node.js 18, install, lint, and test
- Add deploy job that runs after CI: installs Railway CLI and deploys backend & frontend services with non-interactive flag